### PR TITLE
restore the cursor at the end of the alternate_screen example

### DIFF
--- a/examples/src/bin/alternate_screen.rs
+++ b/examples/src/bin/alternate_screen.rs
@@ -29,7 +29,7 @@ fn print_wait_screen() -> Result<()> {
         // 1 second delay
         thread::sleep(time::Duration::from_secs(1));
     }
-
+    cursor.show()?; // we must restore the cursor
     Ok(())
 }
 
@@ -39,7 +39,7 @@ fn print_wait_screen_on_alternate_window() -> Result<()> {
     print_wait_screen()
 }
 
-// cargo run --example alternate_screen
+// cargo run --bin alternate_screen
 fn main() -> Result<()> {
     print_wait_screen_on_alternate_window()
 }

--- a/examples/src/bin/alternate_screen_command.rs
+++ b/examples/src/bin/alternate_screen_command.rs
@@ -3,44 +3,42 @@
 //! unbuffered API.
 
 use std::{
-    thread,
-    time,
     io::{stdout, Write},
+    thread, time,
 };
 
 use crossterm::{
-    AlternateScreen,
-    Clear, ClearType,
-    Color,
-    Crossterm,
-    Goto,
-    Output,
-    PrintStyledFont,
-    queue,
-    Result,
-    style,
+    queue, style, AlternateScreen, Clear, ClearType, Color, Crossterm, Goto, Output,
+    PrintStyledFont, Result,
 };
 
 fn print_wait_screen() -> Result<()> {
     let mut stdout = stdout();
     queue!(stdout, Clear(ClearType::All))?;
     queue!(stdout, Goto(0, 0))?;
-    queue!(stdout, Output(
-        "Welcome to the wait screen.\n\
-         Please wait a few seconds until we arrive back at the main screen.\n\
-         Progress: ".to_string(),
-    ))?;
+    queue!(
+        stdout,
+        Output(
+            "Welcome to the wait screen.\n\
+             Please wait a few seconds until we arrive back at the main screen.\n\
+             Progress: "
+                .to_string(),
+        )
+    )?;
     stdout.flush()?;
     // print some progress example.
     let items = 5;
     for i in 1..=items {
         // print the current counter at the line of `Seconds to Go: {counter}`
         queue!(stdout, Goto(10, 2))?;
-        queue!(stdout, PrintStyledFont(
-            style(format!("{} of the {} items processed", i, items))
-                .with(Color::Red)
-                .on(Color::Blue)
-        ))?;
+        queue!(
+            stdout,
+            PrintStyledFont(
+                style(format!("{} of the {} items processed", i, items))
+                    .with(Color::Red)
+                    .on(Color::Blue)
+            )
+        )?;
         stdout.flush()?;
         // 1 second delay
         thread::sleep(time::Duration::from_secs(1));
@@ -62,4 +60,3 @@ fn print_wait_screen_on_alternate_window() -> Result<()> {
 fn main() -> Result<()> {
     print_wait_screen_on_alternate_window()
 }
-

--- a/examples/src/bin/alternate_screen_command.rs
+++ b/examples/src/bin/alternate_screen_command.rs
@@ -1,0 +1,65 @@
+//! This is the same than alternate_screen but using
+//! the command API instead of the "old style" direct
+//! unbuffered API.
+
+use std::{
+    thread,
+    time,
+    io::{stdout, Write},
+};
+
+use crossterm::{
+    AlternateScreen,
+    Clear, ClearType,
+    Color,
+    Crossterm,
+    Goto,
+    Output,
+    PrintStyledFont,
+    queue,
+    Result,
+    style,
+};
+
+fn print_wait_screen() -> Result<()> {
+    let mut stdout = stdout();
+    queue!(stdout, Clear(ClearType::All))?;
+    queue!(stdout, Goto(0, 0))?;
+    queue!(stdout, Output(
+        "Welcome to the wait screen.\n\
+         Please wait a few seconds until we arrive back at the main screen.\n\
+         Progress: ".to_string(),
+    ))?;
+    stdout.flush()?;
+    // print some progress example.
+    let items = 5;
+    for i in 1..=items {
+        // print the current counter at the line of `Seconds to Go: {counter}`
+        queue!(stdout, Goto(10, 2))?;
+        queue!(stdout, PrintStyledFont(
+            style(format!("{} of the {} items processed", i, items))
+                .with(Color::Red)
+                .on(Color::Blue)
+        ))?;
+        stdout.flush()?;
+        // 1 second delay
+        thread::sleep(time::Duration::from_secs(1));
+    }
+    Ok(())
+}
+
+/// print wait screen on alternate screen, then switch back.
+fn print_wait_screen_on_alternate_window() -> Result<()> {
+    let _alt = AlternateScreen::to_alternate(false)?;
+    let crossterm = Crossterm::new();
+    let cursor = crossterm.cursor();
+    cursor.hide()?;
+    print_wait_screen()?;
+    cursor.show() // we must restore the cursor
+}
+
+// cargo run --bin alternate_screen_command
+fn main() -> Result<()> {
+    print_wait_screen_on_alternate_window()
+}
+

--- a/examples/src/bin/style.rs
+++ b/examples/src/bin/style.rs
@@ -118,11 +118,7 @@ fn print_all_foreground_colors_with_enum() {
 
 /// Print all available foreground colors | demonstration.
 fn print_all_foreground_colors_with_method() {
-    println!(
-        "Black : \t\t       {} {}\n",
-        "■".black(),
-        Attribute::Reset
-    );
+    println!("Black : \t\t       {} {}\n", "■".black(), Attribute::Reset);
     println!(
         "DarkGrey : \t\t     {} {}\n",
         "■".dark_grey(),
@@ -140,11 +136,7 @@ fn print_all_foreground_colors_with_method() {
         "■".dark_cyan(),
         Attribute::Reset
     );
-    println!(
-        "Green : \t\t       {} {}\n",
-        "■".green(),
-        Attribute::Reset
-    );
+    println!("Green : \t\t       {} {}\n", "■".green(), Attribute::Reset);
     println!(
         "DarkGreen : \t\t   {} {}\n",
         "■".dark_green(),
@@ -166,22 +158,14 @@ fn print_all_foreground_colors_with_method() {
         "■".dark_magenta(),
         Attribute::Reset
     );
-    println!(
-        "Yellow : \t\t      {} {}\n",
-        "■".yellow(),
-        Attribute::Reset
-    );
+    println!("Yellow : \t\t      {} {}\n", "■".yellow(), Attribute::Reset);
     println!(
         "DarkYellow : \t\t  {} {}\n",
         "■".dark_yellow(),
         Attribute::Reset
     );
     println!("Grey : \t\t        {} {}\n", "■".grey(), Attribute::Reset);
-    println!(
-        "White : \t\t       {} {}\n",
-        "■".white(),
-        Attribute::Reset
-    );
+    println!("White : \t\t       {} {}\n", "■".white(), Attribute::Reset);
 }
 
 /// Print all available foreground colors | demonstration.
@@ -293,11 +277,7 @@ fn print_all_background_colors_with_method() {
         "■".on_dark_grey(),
         Attribute::Reset
     );
-    println!(
-        "Red : \t\t         {} {}\n",
-        "■".on_red(),
-        Attribute::Reset
-    );
+    println!("Red : \t\t         {} {}\n", "■".on_red(), Attribute::Reset);
     println!(
         "DarkRed : \t\t     {} {}\n",
         "■".on_dark_red(),


### PR DESCRIPTION
If we don't do it, the terminal has no cursor after execution of the example.