### PR TITLE
Add example showcasing mixed input modes

### DIFF
--- a/examples/src/bin/mixed_input.rs
+++ b/examples/src/bin/mixed_input.rs
@@ -1,0 +1,46 @@
+//! Switching between input modes.
+
+use crossterm::{Result, RawScreen, Terminal, TerminalInput, ClearType, InputEvent, KeyEvent, Crossterm};
+use std::{thread, time::Duration};
+
+fn test(terminal: &Terminal, input: &TerminalInput) -> Result<()> {
+    let _raw = RawScreen::into_raw_mode()?;
+    terminal.clear(ClearType::All)?;
+    terminal.write("press `q` to exit test")?;
+
+    let mut stdin = input.read_async();
+
+    loop {
+        if let Some(event) = stdin.next() {
+            match event {
+                InputEvent::Keyboard(KeyEvent::Char('q')) => break,
+                _ => (),
+            }
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    terminal.clear(ClearType::All)?;
+    Ok(())
+}
+
+// cargo run --example mixed_input
+fn main() -> Result<()> {
+    let crossterm = Crossterm::new();
+    let terminal = crossterm.terminal();
+    let input = crossterm.input();
+
+    loop {
+        println!("Type `exit` or `test`");
+        let line = input.read_line()?;
+
+        match line.as_str() {
+            "test" => test(&terminal, &input)?,
+            "exit" => break,
+            _ => println!("try `exit` or `test`"),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Showcases an issue I'm having as an example.

I'm having this issue on Windows 10.

When using `read_async`, the second time `test` is run there are no inputs.
Switching to `read_sync` allows this to work.